### PR TITLE
Smart Reply Timeout Toggle

### DIFF
--- a/api_implementation/src/main/java/xyz/klinker/messenger/api/implementation/ApiUtils.kt
+++ b/api_implementation/src/main/java/xyz/klinker/messenger/api/implementation/ApiUtils.kt
@@ -1269,6 +1269,15 @@ object ApiUtils {
     }
 
     /**
+     * Update the smart reply timeout setting.
+     */
+    fun updateSmartReplyTimeout(accountId: String?, useSmartReplyTimeout: Boolean) {
+        if (accountId != null) {
+            updateSetting(accountId, "smart_reply_timeout", "boolean", useSmartReplyTimeout)
+        }
+    }
+
+    /**
      * Update the internal browser setting.
      */
     fun updateInternalBrowser(accountId: String?, useBrowser: Boolean) {

--- a/app/src/main/java/xyz/klinker/messenger/fragment/message/SmartReplyManager.kt
+++ b/app/src/main/java/xyz/klinker/messenger/fragment/message/SmartReplyManager.kt
@@ -18,6 +18,7 @@ import xyz.klinker.messenger.R
 import xyz.klinker.messenger.activity.SettingsActivity
 import xyz.klinker.messenger.api.implementation.firebase.AnalyticsHelper
 import xyz.klinker.messenger.fragment.message.send.SendMessageManager
+import xyz.klinker.messenger.shared.data.Settings
 import xyz.klinker.messenger.shared.util.DensityUtil
 import java.lang.Exception
 
@@ -62,7 +63,9 @@ class SmartReplyManager(private val fragment: MessageListFragment) {
                             messageEntry.requestFocus()
 
                             hideContainer()
-                            sendManager.requestPermissionThenSend(false, 2000)
+                            if (Settings.smartReplyTimeout) {
+                                sendManager.requestPermissionThenSend(false, 2000)
+                            }
                         }
 
                         layout

--- a/app/src/main/java/xyz/klinker/messenger/fragment/settings/FeatureSettingsFragment.kt
+++ b/app/src/main/java/xyz/klinker/messenger/fragment/settings/FeatureSettingsFragment.kt
@@ -14,7 +14,6 @@ import xyz.klinker.messenger.api.implementation.Account
 import xyz.klinker.messenger.api.implementation.ApiUtils
 import xyz.klinker.messenger.activity.passcode.PasscodeSetupActivity
 import xyz.klinker.messenger.activity.passcode.PasscodeVerificationActivity
-import xyz.klinker.messenger.fragment.PrivateConversationListFragment
 import xyz.klinker.messenger.shared.data.Settings
 import xyz.klinker.messenger.shared.service.QuickComposeNotificationService
 import xyz.klinker.messenger.shared.util.RedirectToMyAccount
@@ -27,6 +26,7 @@ class FeatureSettingsFragment : MaterialPreferenceFragment() {
         addPreferencesFromResource(R.xml.settings_features)
         initSecurePrivateConversations()
         initSmartReplies()
+        initSmartReplyTimeout()
         initInternalBrowser()
         initQuickCompose()
         initDelayedSending()
@@ -64,6 +64,15 @@ class FeatureSettingsFragment : MaterialPreferenceFragment() {
         preference.setOnPreferenceChangeListener { _, o ->
             val useSmartReplies = o as Boolean
             ApiUtils.updateSmartReplies(Account.accountId, useSmartReplies)
+            true
+        }
+    }
+
+    private fun initSmartReplyTimeout() {
+        val preference = findPreference(getString(R.string.pref_smart_reply_timeout))
+        preference.setOnPreferenceChangeListener { _, o ->
+            val useSmartReplyTimeout = o as Boolean
+            ApiUtils.updateSmartReplyTimeout(Account.accountId, useSmartReplyTimeout)
             true
         }
     }

--- a/shared/src/main/java/xyz/klinker/messenger/shared/data/Settings.kt
+++ b/shared/src/main/java/xyz/klinker/messenger/shared/data/Settings.kt
@@ -65,6 +65,7 @@ object Settings {
     var historyInNotifications: Boolean = false
     var dismissNotificationAfterReply: Boolean = false
     var smartReplies: Boolean = true
+    var smartReplyTimeout: Boolean = true
     var internalBrowser: Boolean = false
     var snooze: Long = 0
     var repeatNotifications: Long = 0
@@ -160,6 +161,7 @@ object Settings {
         this.historyInNotifications = sharedPrefs.getBoolean(context.getString(R.string.pref_history_in_notifications), true)
         this.dismissNotificationAfterReply = sharedPrefs.getBoolean(context.getString(R.string.pref_dismiss_notifications_on_reply_android_p), false)
         this.smartReplies = sharedPrefs.getBoolean(context.getString(R.string.pref_smart_reply), true)
+        this.smartReplyTimeout = sharedPrefs.getBoolean(context.getString(R.string.pref_smart_reply_timeout), true)
         this.internalBrowser = sharedPrefs.getBoolean(context.getString(R.string.pref_internal_browser), true)
         this.drivingMode = sharedPrefs.getBoolean(context.getString(R.string.pref_driving_mode), false)
         this.vacationMode = sharedPrefs.getBoolean(context.getString(R.string.pref_vacation_mode), false)

--- a/shared/src/main/res/values/preferences.xml
+++ b/shared/src/main/res/values/preferences.xml
@@ -125,6 +125,7 @@
     <string name="pref_secure_private_conversations" translatable="false">private_conversations_passcode</string>
     <string name="pref_private_conversation_passcode_last_entry" translatable="false">private_conversations_passcode_last_entry</string>
     <string name="pref_smart_reply" translatable="false">smart_reply</string>
+    <string name="pref_smart_reply_timeout" translatable="false">smart_reply_timeout</string>
     <string name="pref_internal_browser" translatable="false">internal_browser</string>
     <string name="pref_delayed_sending" translatable="false">delayed_sending</string>
     <string name="pref_cleanup_messages" translatable="false">cleanup_old_messages</string>

--- a/shared/src/main/res/values/strings.xml
+++ b/shared/src/main/res/values/strings.xml
@@ -561,6 +561,8 @@
     <string name="use_smart_replies">Suggest Smart Replies</string>
     <string name="use_smart_replies_summary">Pulse will suggest relevant replies, when available. These are generated directly on the device, not a remote server</string>
     <string name="use_smart_replies_dialog">Pulse will suggest relevant replies, when available. These are generated directly on the device, not a remote server.\n\nIf you would rather not use this feature, it can be disabled from settings.</string>
+    <string name="smart_reply_timeout">Send Smart Replies After Delay</string>
+    <string name="smart_reply_timeout_summary">Smart replies will automatically send after a short delay</string>
     <string name="use_smart_reply_settings">Settings</string>
     <string name="message_backup">Message Backup</string>
     <string name="message_backup_pref_summary">Worried about losing your messages? Pulse has you covered</string>

--- a/shared/src/main/res/xml/settings_features.xml
+++ b/shared/src/main/res/xml/settings_features.xml
@@ -42,6 +42,12 @@
             android:summary="@string/use_smart_replies_summary"
             android:defaultValue="true" />
 
+        <SwitchPreference
+            android:key="@string/pref_smart_reply_timeout"
+            android:title="@string/smart_reply_timeout"
+            android:summary="@string/smart_reply_timeout_summary"
+            android:defaultValue="true" />
+
         <Preference
             android:key="@string/pref_auto_reply"
             android:title="@string/auto_reply_configuration"


### PR DESCRIPTION
This change adds a setting to toggle the automatic sending of smart replies after a timeout. Most of the time when I use the smart replies, I like to add extra text after the suggestion. I know it is possible to hit the (x) to stop the reply from sending, but I thought it would be a good idea to allow it to be configurable and I would enjoy not having to cancel it each time.

### Smart Reply Toggle in the UI
<img src="https://user-images.githubusercontent.com/38381547/72028573-a970d680-3248-11ea-95db-957ae40ba78e.png" alt="Screenshot of New Setting" width="300">

Currently, I have set the title of the setting to "Send Smart Replies After Delay" and its summary to "Smart replies will automatically send after a short delay". These are definitely subject to change so please let me know what you'd like them to say here.

This change ended up being smaller than I expected so I'm sending it straight to PR.