### PR TITLE
Handling default SMS on Android Q with Roles Manager

### DIFF
--- a/shared/src/main/java/xyz/klinker/messenger/shared/util/PermissionsUtils.kt
+++ b/shared/src/main/java/xyz/klinker/messenger/shared/util/PermissionsUtils.kt
@@ -102,16 +102,12 @@ object PermissionsUtils {
         }
 
         if (AndroidVersionUtil.isAndroidQ) {
-            // Android Q has not been working with the normal ACTION_CHANGE_DEFAULT prompt, and I have no clue why....
-            AlertDialog.Builder(context)
-                    .setMessage(R.string.google_requires_default_sms)
-                    .setNegativeButton(R.string.google_requires_default_sms_policy) { _, _ ->
-                        val policy = Intent(Intent.ACTION_VIEW, Uri.parse("https://android-developers.googleblog.com/2018/10/providing-safe-and-secure-experience.html"))
-                        startDefaultApp(policy)
-                    }.setPositiveButton(R.string.ok) { _, _ ->
-                        startDefaultApp(Intent(android.provider.Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS))
-                    }.setCancelable(false)
-                    .show()
+            // At Android Q, Google inroduced roles to handle the default system apps.
+            val roleManager = context.getSystemService(RoleManager::class.java)
+            if (roleManager != null && roleManager.isRoleAvailable(RoleManager.ROLE_SMS) && !roleManager.isRoleHeld(RoleManager.ROLE_SMS)) {
+                val intent = roleManager.createRequestRoleIntent(RoleManager.ROLE_SMS)
+                startDefaultApp(intent)
+            }
         } else {
             val intent = Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT)
             intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, context.applicationContext.packageName)


### PR DESCRIPTION
SMS handling on Android Q is done as suggested by the documentation here:
https://developer.android.com/reference/android/app/role/RoleManager