### PR TITLE
Fixing Crash When Attempting to Attach Media From Bubble Notification

### DIFF
--- a/app/src/main/java/xyz/klinker/messenger/fragment/message/MessageSearchHelper.kt
+++ b/app/src/main/java/xyz/klinker/messenger/fragment/message/MessageSearchHelper.kt
@@ -33,6 +33,8 @@ class MessageSearchHelper(private val fragment: MessageListFragment) : MaterialS
     }
     
     fun closeSearch(): Boolean {
+        if (!this::searchView.isInitialized) return false
+
         if (searchView.isSearchOpen) {
             searchFragment?.search(null)
             searchView.closeSearch()


### PR DESCRIPTION
On Android 11, attempting to attach an image, gif, or other media from inside the bubble notification activity causes a crash. The media is not attached and the bubble is forced closed. This is caused by the lack of the `MaterialSearchView` in the layout.

This change adds a check to ensure the `searchView` is initialized before attempting to close it. With this change, all types of media can now be attached and sent from the bubble.